### PR TITLE
Enchancements

### DIFF
--- a/SustenetClient.csproj
+++ b/SustenetClient.csproj
@@ -24,28 +24,37 @@
     <Compile Remove="cfg\**" />
     <Compile Remove="libs\**" />
     <Compile Remove="src\Master\**" />
+    <Compile Remove="src\Transport\Messages\BaseServerHandlers\**" />
+    <Compile Remove="src\Transport\Messages\ClusterClientHandlers\**" />
+    <Compile Remove="src\Transport\Messages\ClusterHandlers\**" />
+    <Compile Remove="src\Transport\Messages\MasterHandlers\**" />
     <Compile Remove="src\World\**" />
     <Compile Remove="tests\**" />
     <EmbeddedResource Remove="cfg\**" />
     <EmbeddedResource Remove="libs\**" />
     <EmbeddedResource Remove="src\Master\**" />
+    <EmbeddedResource Remove="src\Transport\Messages\BaseServerHandlers\**" />
+    <EmbeddedResource Remove="src\Transport\Messages\ClusterClientHandlers\**" />
+    <EmbeddedResource Remove="src\Transport\Messages\ClusterHandlers\**" />
+    <EmbeddedResource Remove="src\Transport\Messages\MasterHandlers\**" />
     <EmbeddedResource Remove="src\World\**" />
     <EmbeddedResource Remove="tests\**" />
     <None Remove="cfg\**" />
     <None Remove="libs\**" />
     <None Remove="src\Master\**" />
+    <None Remove="src\Transport\Messages\BaseServerHandlers\**" />
+    <None Remove="src\Transport\Messages\ClusterClientHandlers\**" />
+    <None Remove="src\Transport\Messages\ClusterHandlers\**" />
+    <None Remove="src\Transport\Messages\MasterHandlers\**" />
     <None Remove="src\World\**" />
     <None Remove="tests\**" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="src\Clients\ClusterClient.cs" />
+    <Compile Remove="src\Options.cs" />
     <Compile Remove="src\Sustenet.cs" />
     <Compile Remove="src\Transport\BaseServer.cs" />
-    <Compile Remove="src\Transport\Messages\BaseServerHandler.cs" />
-    <Compile Remove="src\Transport\Messages\ClusterClientHandler.cs" />
-    <Compile Remove="src\Transport\Messages\ClusterHandler.cs" />
-    <Compile Remove="src\Transport\Messages\MasterHandler.cs" />
     <Compile Remove="src\Utils\Config.cs" />
     <Compile Remove="src\Utils\Security\PassphraseGenerator.cs" />
   </ItemGroup>

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -231,6 +231,7 @@ namespace Sustenet.Clients
                     #region Initialization Section
                     { (int)ServerPackets.message, this.Message },
                     { (int)ServerPackets.initializeLogin, this.InitializeClient },
+                    { (int)ServerPackets.udpReady, this.UdpConnected },
                     #endregion
 
                     #region Movement Section

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -97,9 +97,19 @@ namespace Sustenet.Clients
                 receivedData = new Packet();
             };
 
-            onReceived.Run += (data) =>
+            onReceived.Run += (protocol, data) =>
             {
-                receivedData.Reset(HandleData(data));
+                switch(protocol)
+                {
+                    case Protocols.TCP:
+                        receivedData.Reset(HandleTcpData(data));
+                        return;
+
+                    case Protocols.UDP:
+                        HandleUdpData(data);
+                        return;
+                }
+
             };
 
             InitializeClientData();

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -115,6 +115,7 @@ namespace Sustenet.Clients
             InitializeClientData();
         }
 
+        #region Connection Functions
         public void Login(string username)
         {
             // If the user currently doesn't have a username, let them attempt to login.
@@ -132,14 +133,17 @@ namespace Sustenet.Clients
                 case ConnectionType.MasterServer:
                     activeConnection = connectType;
                     tcp.Connect(this, IPAddress.Parse(masterConnection.Ip), masterConnection.Port);
+                    udp.Connect(this, IPAddress.Parse(masterConnection.Ip), masterConnection.Port, masterConnection.LocalPort);
                     break;
 
                 case ConnectionType.ClusterServer:
                     activeConnection = connectType;
                     tcp.Connect(this, IPAddress.Parse(clusterConnection.Ip), clusterConnection.Port);
+                    udp.Connect(this, IPAddress.Parse(clusterConnection.Ip), clusterConnection.Port, clusterConnection.LocalPort);
                     break;
             }
         }
+        #endregion
 
         #region Data Functions
         private bool HandleTcpData(byte[] data)

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -220,8 +220,14 @@ namespace Sustenet.Clients
             {
                 packetHandlers = new Dictionary<int, PacketHandler>()
                 {
+                    #region Initialization Section
                     { (int)ServerPackets.message, this.Message },
-                    { (int)ServerPackets.initializeLogin, this.InitializeClient }
+                    { (int)ServerPackets.initializeLogin, this.InitializeClient },
+                    #endregion
+
+                    #region Movement Section
+                    { (int)ServerPackets.updatePosition, this.UpdatePosition }
+                    #endregion
                 };
             }
         }

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -133,13 +133,11 @@ namespace Sustenet.Clients
                 case ConnectionType.MasterServer:
                     activeConnection = connectType;
                     tcp.Connect(this, IPAddress.Parse(masterConnection.Ip), masterConnection.Port);
-                    udp.Connect(this, IPAddress.Parse(masterConnection.Ip), masterConnection.Port, masterConnection.LocalPort);
                     break;
 
                 case ConnectionType.ClusterServer:
                     activeConnection = connectType;
                     tcp.Connect(this, IPAddress.Parse(clusterConnection.Ip), clusterConnection.Port);
-                    udp.Connect(this, IPAddress.Parse(clusterConnection.Ip), clusterConnection.Port, clusterConnection.LocalPort);
                     break;
             }
         }

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -115,7 +115,11 @@ namespace Sustenet.Clients
                         HandleUdpData(data);
                         return;
                 }
+            };
 
+            onInitialized.Run += () =>
+            {
+                this.MoveTo(new float[] { 1, 2, 3 }); // TEST: Remove later.
             };
 
             InitializeClientData();

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -132,7 +132,7 @@ namespace Sustenet.Clients
         }
 
         #region Data Functions
-        private bool HandleData(byte[] data)
+        private bool HandleTcpData(byte[] data)
         {
             int packetLength = 0;
 
@@ -178,6 +178,25 @@ namespace Sustenet.Clients
                 return true;
             }
 
+            return false;
+        }
+
+        private bool HandleUdpData(byte[] data)
+        {
+            using(Packet packet = new Packet(data))
+            {
+                int packetLength = packet.ReadInt();
+                data = packet.ReadBytes(packetLength);
+            }
+
+            ThreadManager.ExecuteOnMainThread(() =>
+            {
+                using(Packet packet = new Packet(data))
+                {
+                    int packetId = packet.ReadInt();
+                    packetHandlers[packetId](packet);
+                }
+            });
             return false;
         }
 

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -85,7 +85,12 @@ namespace Sustenet.Clients
         /// </summary>
         protected static Dictionary<int, PacketHandler> packetHandlers;
 
-        public Client(string _ip = "127.0.0.1", ushort _port = 6256) : base(0)
+        /// <summary>
+        /// After a client logs in successful and gets their username & id back.
+        /// </summary>
+        public BaseEvent onInitialized = new BaseEvent();
+
+        public Client(string _ip = "127.0.0.1", ushort _port = 6256) : base(-1)
         {
             masterConnection = new Connection
             {

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -23,6 +23,7 @@ namespace Sustenet.Clients
     using Transport;
     using Transport.Messages.ClientHandlers;
     using Network;
+    using Utils;
 
     /// <summary>
     /// A standard client that connects to a server.
@@ -39,6 +40,7 @@ namespace Sustenet.Clients
         {
             private IPAddress ip;
             private ushort port;
+            private ushort localPort;
             public string Ip
             {
                 get
@@ -62,6 +64,12 @@ namespace Sustenet.Clients
             {
                 get { return port; }
                 set { port = value; }
+            }
+
+            public ushort LocalPort
+            {
+                get { return localPort; }
+                set { localPort = value; }
             }
         }
 

--- a/src/Clients/Client.cs
+++ b/src/Clients/Client.cs
@@ -22,8 +22,9 @@ namespace Sustenet.Clients
     using System.Collections.Generic;
     using Transport;
     using Transport.Messages.ClientHandlers;
+    using Transport.Messages.BaseClientHandlers;
     using Network;
-    using Utils;
+    using Events;
 
     /// <summary>
     /// A standard client that connects to a server.

--- a/src/Master/MasterServer.cs
+++ b/src/Master/MasterServer.cs
@@ -51,9 +51,15 @@ namespace Sustenet.Master
             {
                 packetHandlers = new Dictionary<int, PacketHandler>()
                 {
+                    #region Initialization Section
                     { (int)ClientPackets.answerPassphrase, this.AnswerPassphrase },
                     { (int)ClientPackets.validateCluster, this.ValidateCluster },
-                    { (int)ClientPackets.validateLogin, this.ValidateLogin }
+                    { (int)ClientPackets.validateLogin, this.ValidateLogin },
+                    #endregion
+
+                    #region Movement Section
+                    { (int)ClientPackets.moveTo, this.ValidateMoveTo }
+                    #endregion
                 };
             }
         }

--- a/src/Master/MasterServer.cs
+++ b/src/Master/MasterServer.cs
@@ -35,7 +35,7 @@ namespace Sustenet.Master
         /// </summary>
         public List<int> clusterIds = new List<int>();
 
-        public MasterServer(int _maxConnections = 0, ushort _port = 6256) : base(_maxConnections, _port)
+        public MasterServer(int _maxConnections = 0, ushort _port = 6256) : base(ServerType.MasterServer, _maxConnections, _port)
         {
             RSAManager.LoadPubKeys();
             AESManager.LoadKeys();

--- a/src/Network/Packet.cs
+++ b/src/Network/Packet.cs
@@ -31,9 +31,9 @@ namespace Sustenet.Network
     /// </summary>
     public class Packet : IDisposable
     {
-        private List<byte> buffer;
+        private List<byte> buffer = new List<byte>();
         private byte[] readableBuffer;
-        private int readPos;
+        private int readPos = 0;
 
         /// <summary>
         /// Creates an empty packet without an ID.
@@ -44,13 +44,13 @@ namespace Sustenet.Network
         /// Creates an empty packet with an ID. Used for sending data.
         /// </summary>
         /// <param name="_id">The packet ID.</param>
-        public Packet(int _id) { buffer = new List<byte>(); readPos = 0; Write(_id); }
+        public Packet(int _id) { Write(_id); }
 
         /// <summary>
         /// Creates a packet and sets data to prepare it for reading. Used for receiving data.
         /// </summary>
         /// <param name="data">The bytes to add to the packet.</param>
-        public Packet(byte[] data) { buffer = new List<byte>(); readPos = 0; SetBytes(data); }
+        public Packet(byte[] data) { SetBytes(data); }
 
         #region Packet Functions
         /// <summary>

--- a/src/Network/PacketTypes.cs
+++ b/src/Network/PacketTypes.cs
@@ -41,6 +41,10 @@ namespace Sustenet.Network
         /// a valid user.
         /// </summary>
         initializeLogin = 1,
+        /// <summary>
+        /// Tells a client that the UDP connection is ready.
+        /// </summary>
+        udpReady = 2,
 
         #region Movement (2000-2999)
         updatePosition = 2000 // TODO: Move to Cluster once clusters are being used.
@@ -77,6 +81,10 @@ namespace Sustenet.Network
         /// Logs in with a username.
         /// </summary>
         validateLogin = 1,
+        /// <summary>
+        /// Sends an ID to a server to start a UDP connection.
+        /// </summary>
+        startUdp = 2,
 
         #region Movement (2000,2999)
         moveTo = 2000

--- a/src/Network/PacketTypes.cs
+++ b/src/Network/PacketTypes.cs
@@ -40,7 +40,11 @@ namespace Sustenet.Network
         /// If ran on a Cluster Server, asks the Master Server if they're actual
         /// a valid user.
         /// </summary>
-        initializeLogin = 1
+        initializeLogin = 1,
+
+        #region Movement (2000-2999)
+        updatePosition = 2000 // TODO: Move to Cluster once clusters are being used.
+        #endregion
     }
 
     /// <summary>
@@ -72,6 +76,10 @@ namespace Sustenet.Network
         /// <summary>
         /// Logs in with a username.
         /// </summary>
-        validateLogin = 1
+        validateLogin = 1,
+
+        #region Movement (2000,2999)
+        moveTo = 2000
+        #endregion
     }
 }

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -26,7 +26,7 @@ namespace Sustenet
         public class OptionsData
         {
             public bool client = false;
-            public int maxClients = 5000;
+            public int maxClients = 1;
             public bool cluster = false;
             public bool master = false;
         }

--- a/src/Sustenet.cs
+++ b/src/Sustenet.cs
@@ -42,7 +42,13 @@ namespace Sustenet
                 clients = new Clients.Client[options.maxClients];
                 for(int i = 0; i < options.maxClients; i++)
                 {
-                    clients[i] = new Clients.Client();
+                    Clients.Client client = new Clients.Client();
+                    clients[i] = client;
+                    clients[i].onConnected.Run += () =>
+                    {
+                        client.Login("Mako");
+                    };
+
                     clients[i].Connect();
                 }
                 Utilities.WriteLine($"Finished connecting {options.maxClients} clients to the server.");

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -256,11 +256,6 @@ namespace Sustenet.Transport
                     socket.Connect(endpoint);
                     socket.BeginReceive(ReceiveCallback, client);
 
-                    using(Packet packet = new Packet())
-                    {
-                        client.SendUdpData(packet);
-                    }
-
                     client.onConnected.RaiseEvent();
                 }
                 catch(Exception e)

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -108,13 +108,11 @@ namespace Sustenet.Transport
                 try
                 {
                     int byteLength;
-                    lock(stream)
-                    {
-                        if(stream == null)
-                            return;
 
-                        byteLength = stream.EndRead(ar);
-                    }
+                    if(stream == null)
+                        return;
+
+                    byteLength = stream.EndRead(ar);
 
                     if(byteLength <= 0)
                     {
@@ -129,11 +127,8 @@ namespace Sustenet.Transport
 
                     client.onReceived.RaiseEvent(data);
 
-                    lock(stream)
-                    {
-                        if(stream != null)
-                            stream.BeginRead(receiveBuffer, 0, bufferSize, ReceiveCallback, client);
-                    }
+                    if(stream != null)
+                        stream.BeginRead(receiveBuffer, 0, bufferSize, ReceiveCallback, client);
                 }
                 catch(Exception e)
                 {
@@ -184,31 +179,25 @@ namespace Sustenet.Transport
 
                 try
                 {
-                    lock(socket)
-                    {
-                        if(socket != null)
-                            socket.EndConnect(ar);
+                    if(socket != null)
+                        socket.EndConnect(ar);
 
-                        if(!socket.Connected)
-                        {
-                            DebugClient(client.id, $"Failed to connect to the server at {socket.Client.RemoteEndPoint}.");
-                            return;
-                        }
+                    if(!socket.Connected)
+                    {
+                        DebugClient(client.id, $"Failed to connect to the server at {socket.Client.RemoteEndPoint}.");
+                        return;
                     }
 
                     DebugClient(client.id, $"Connected to server at {socket.Client.RemoteEndPoint}.");
 
-                    lock(stream)
+                    if(stream == null)
                     {
-                        if(stream == null)
-                        {
-                            stream = socket.GetStream();
-                        }
-
-                        client.onConnected.RaiseEvent();
-
-                        stream.BeginRead(receiveBuffer, 0, bufferSize, ReceiveCallback, client);
+                        stream = socket.GetStream();
                     }
+
+                    client.onConnected.RaiseEvent();
+
+                    stream.BeginRead(receiveBuffer, 0, bufferSize, ReceiveCallback, client);
                 }
                 catch(Exception e)
                 {

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -72,12 +72,7 @@ namespace Sustenet.Transport
                 {
                     if(socket != null)
                     {
-                        if(stream != null)
-                        {
-                            stream.Dispose();
-                        }
-
-                        socket.Dispose();
+                        socket.Close();
                     }
 
                     socket = _socket;
@@ -232,10 +227,7 @@ namespace Sustenet.Transport
                     if(disposing)
                     {
                         if(socket != null)
-                            socket.Dispose();
-
-                        if(stream != null)
-                            stream.Dispose();
+                            socket.Close();
                     }
 
                     disposed = true;
@@ -307,7 +299,7 @@ namespace Sustenet.Transport
                     if(disposing)
                     {
                         if(socket != null)
-                            socket.Dispose();
+                            socket.Close();
                     }
 
                     if(endPoint != null)

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -23,7 +23,6 @@ namespace Sustenet.Transport
     using Network;
     using Events;
     using Utils;
-    using Messages.BaseClientHandlers;
 
     /// <summary>
     /// The core for all clients. Handles basic functionality like sending
@@ -240,7 +239,7 @@ namespace Sustenet.Transport
             public IPEndPoint endpoint;
 
             /// <summary>
-            /// Prepares for a UDP connection to a server.
+            /// Prepares a client for a UDP connection to a server.
             /// </summary>
             /// <param name="ip">The IP Address to set the endpoint to.</param>
             /// <param name="port">The port to set the endpoint to.</param>

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -297,12 +297,10 @@ namespace Sustenet.Transport
                 {
                     if(disposing)
                     {
-                        if(socket != null)
-                            socket.Close();
+                        // Managed resources
                     }
 
-                    if(endpoint != null)
-                        endpoint = null;
+                    // Unmanaged resources
 
                     disposed = true;
                 }

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -264,8 +264,9 @@ namespace Sustenet.Transport
 
                     client.onConnected.RaiseEvent();
                 }
-                catch
+                catch(Exception e)
                 {
+                    Utilities.WriteLine(e);
                     client.onDisconnected.RaiseEvent(); // TODO: Pass a TypeEnum.UDP enum to differentiate instructions?
                 }
             }

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -132,7 +132,7 @@ namespace Sustenet.Transport
                     lock(stream)
                     {
                         if(stream != null)
-                            stream.BeginRead(receiveBuffer, 0, bufferSize, ReceiveCallback, null);
+                            stream.BeginRead(receiveBuffer, 0, bufferSize, ReceiveCallback, client);
                     }
                 }
                 catch(Exception e)
@@ -166,7 +166,7 @@ namespace Sustenet.Transport
                         receiveBuffer = new byte[bufferSize];
                     }
 
-                    socket.BeginConnect(ip, port, ConnectCallback, null);
+                    socket.BeginConnect(ip, port, ConnectCallback, client);
                 }
                 catch
                 {
@@ -207,7 +207,7 @@ namespace Sustenet.Transport
 
                         client.onConnected.RaiseEvent();
 
-                        stream.BeginRead(receiveBuffer, 0, bufferSize, ReceiveCallback, null);
+                        stream.BeginRead(receiveBuffer, 0, bufferSize, ReceiveCallback, client);
                     }
                 }
                 catch(Exception e)
@@ -276,7 +276,7 @@ namespace Sustenet.Transport
                 try
                 {
                     byte[] data = socket.EndReceive(ar, ref endPoint);
-                    socket.BeginReceive(ReceiveCallback, null);
+                    socket.BeginReceive(ReceiveCallback, client);
 
                     if(data.Length < 4)
                     {

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -277,7 +277,7 @@ namespace Sustenet.Transport
 
                 try
                 {
-                    byte[] data = socket.EndReceive(ar, ref endPoint);
+                    byte[] data = socket.EndReceive(ar, ref endpoint);
                     socket.BeginReceive(ReceiveCallback, client);
 
                     if(data.Length < 4)
@@ -306,8 +306,8 @@ namespace Sustenet.Transport
                             socket.Close();
                     }
 
-                    if(endPoint != null)
-                        endPoint = null;
+                    if(endpoint != null)
+                        endpoint = null;
 
                     disposed = true;
                 }

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -175,7 +175,7 @@ namespace Sustenet.Transport
             /// Triggered after BeginConnect().
             /// </summary>
             /// <param name="ar">Result from BeginConnect().</param>
-            public void ConnectCallback(IAsyncResult ar)
+            public void ConnectCallback(IAsyncResult ar, IPAddress ip)
             {
                 BaseClient client = (BaseClient)ar.AsyncState;
 

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -206,7 +206,7 @@ namespace Sustenet.Transport
                 catch(Exception e)
                 {
                     Utilities.WriteLine(e);
-                    DebugClient(client.id, "Error while trying to connect.");
+                    DebugClient(client.id, "Error while trying to connect via TCP.");
                 }
             }
             #endregion

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -232,7 +232,7 @@ namespace Sustenet.Transport
 
         public class UdpHandler : IDisposable
         {
-            public UdpClient socket;
+            public static UdpClient socket;
             public IPEndPoint endPoint;
 
             /// <summary>
@@ -247,7 +247,8 @@ namespace Sustenet.Transport
                 {
                     endPoint = new IPEndPoint(ip, port);
 
-                    socket = new UdpClient(localPort);
+                    if(socket == null)
+                        socket = new UdpClient(localPort);
 
                     socket.Connect(endPoint);
                     socket.BeginReceive(new AsyncCallback(ReceiveCallback), client);

--- a/src/Transport/BaseClient.cs
+++ b/src/Transport/BaseClient.cs
@@ -282,8 +282,9 @@ namespace Sustenet.Transport
 
                     client.onReceived.RaiseEvent(Protocols.UDP, data);
                 }
-                catch
+                catch(Exception e)
                 {
+                    Utilities.WriteLine(e);
                     client.onDisconnected.RaiseEvent();
                 }
             }

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -25,6 +25,7 @@ namespace Sustenet.Transport
     using Events;
     using Network;
     using Utils;
+    using Messages.BaseServerHandlers;
 
     /// <summary>
     /// Base class of all server types. Takes in clients.
@@ -100,7 +101,7 @@ namespace Sustenet.Transport
         }
 
         /// <summary>
-        /// Handles new connections.
+        /// Handles new TCP connections.
         /// </summary>
         /// <param name="ar">Async Result, the state contains this instance.</param>
         private static void OnTcpConnectCallback(IAsyncResult ar)
@@ -125,6 +126,10 @@ namespace Sustenet.Transport
             }
         }
 
+        /// <summary>
+        /// Handles new UDP connections.
+        /// </summary>
+        /// <param name="ar">Asyn Result, the state contains this instance.</param>
         private static void OnUdpReceiveCallback(IAsyncResult ar)
         {
             BaseServer server = (BaseServer)ar.AsyncState;

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -233,6 +233,10 @@ namespace Sustenet.Transport
                                 return;
                         }
                     };
+                    clients[id].onConnected.Run += () =>
+                    {
+                        this.UdpReady(id);
+                    };
                     // Clear the entry from the server.
                     clients[id].onDisconnected.Run += () => { ClearClient(id); };
 
@@ -355,7 +359,6 @@ namespace Sustenet.Transport
 
         private bool HandleUdpData(int clientId, Packet packet)
         {
-
             int packetLength = packet.ReadInt();
             byte[] packetBytes = packet.ReadBytes(packetLength);
 

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -39,9 +39,10 @@ namespace Sustenet.Transport
 
         private TcpListener tcpListener;
 
-        public ServerType serverType;
-        public int maxConnections;
-        public ushort port;
+        public readonly ServerType serverType;
+        public readonly string serverTypeName;
+        public readonly int maxConnections;
+        public readonly ushort port;
 
         public Dictionary<int, BaseClient> clients = new Dictionary<int, BaseClient>();
         public List<int> releasedIds = new List<int>();
@@ -57,8 +58,10 @@ namespace Sustenet.Transport
         public BaseEvent<int> onDisconnection = new BaseEvent<int>();
         public BaseEvent<byte[]> onReceived = new BaseEvent<byte[]>();
 
-        protected BaseServer(int _maxConnections = 0, ushort _port = 6256)
+        protected BaseServer(ServerType _serverType, int _maxConnections = 0, ushort _port = 6256)
         {
+            serverType = _serverType;
+            serverTypeName = Utilities.SplitByPascalCase(serverType.ToString());
             maxConnections = _maxConnections;
             port = _port == 0 ? (ushort)6256 : _port;
         }
@@ -70,10 +73,6 @@ namespace Sustenet.Transport
         /// <param name="serverType">The type of server to notify in the console.</param>
         protected void Start(ServerType _serverType)
         {
-            serverType = _serverType;
-
-            string serverTypeName = Utilities.SplitByPascalCase(serverType.ToString());
-
             if(Constants.DEBUGGING)
             {
 #pragma warning disable CS0162 // Unreachable code detected

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -135,7 +135,7 @@ namespace Sustenet.Transport
                 byte[] data = BaseClient.UdpHandler.socket.EndReceive(ar, ref endpoint);
                 BaseClient.UdpHandler.socket.BeginReceive(OnUdpReceiveCallback, server);
 
-                if(data.Length <= 4)
+                if(data.Length < 4)
                 {
                     // no ID
                     return;

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -154,6 +154,7 @@ namespace Sustenet.Transport
                     if(server.clients[clientId].udp.endpoint == null)
                     {
                         server.clients[clientId].udp.endpoint = endpoint;
+                        server.clients[clientId].onConnected.RaiseEvent();
                         return;
                     }
 

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -113,7 +113,7 @@ namespace Sustenet.Transport
             }
             catch(Exception e)
             {
-                DebugServer(server.serverType, $"Failed to create a client: {e}");
+                DebugServer(server.serverTypeName, $"Failed to create a client: {e}");
             }
         }
 
@@ -180,7 +180,7 @@ namespace Sustenet.Transport
                     return;
                 }
 
-                DebugServer(serverType, $"{client.Client.RemoteEndPoint} failed to connect. Max connections of {maxConnections} reached.");
+                DebugServer(serverTypeName, $"{client.Client.RemoteEndPoint} failed to connect. Max connections of {maxConnections} reached.");
             }
             catch
             {
@@ -218,7 +218,7 @@ namespace Sustenet.Transport
                     clients.Remove(clientId);
                     releasedIds.Add(clientId); // TODO: Change this to only keep Ids of a certain reusable range.
 
-                    DebugServer(serverType, $"Disconnected Client#{clientId}.");
+                    DebugServer(serverTypeName, $"Disconnected Client#{clientId}.");
                 }
                 catch(Exception e)
                 {
@@ -234,7 +234,7 @@ namespace Sustenet.Transport
                             clients.Remove(clientId);
                             releasedIds.Add(clientId);
                         }
-                        DebugServer(serverType, $"Disconnected Client#{clientId} but with issues: {e}");
+                        DebugServer(serverTypeName, $"Disconnected Client#{clientId} but with issues: {e}");
                     }
                 }
             });
@@ -289,17 +289,14 @@ namespace Sustenet.Transport
 
             return false;
         }
-        #endregion
 
-        public static void DebugServer(string serverTypeName, string msg)
         {
             Console.WriteLine($"({serverTypeName}) {msg}");
         }
 
-        public static void DebugServer(ServerType serverType, string msg)
+        public static void DebugServer(string serverTypeName, string msg)
         {
-            string serverTypeName = Utilities.SplitByPascalCase(serverType.ToString());
-            Utilities.WriteLine($"({serverTypeName}) {msg}");
+            Console.WriteLine($"({serverTypeName}) {msg}");
         }
     }
 }

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -85,7 +85,8 @@ namespace Sustenet.Transport
 
             tcpListener = new TcpListener(IPAddress.Any, port);
             tcpListener.Start();
-            tcpListener.BeginAcceptTcpClient(new AsyncCallback(OnConnectCallback), this);
+            tcpListener.BeginAcceptTcpClient(new AsyncCallback(OnTcpConnectCallback), this);
+
 
             string maxConnectionsValue = (maxConnections == 0 ? "Until it breaks" : Utilities.SplitByPascalCase(maxConnections.ToString()));
 
@@ -96,7 +97,7 @@ namespace Sustenet.Transport
         /// Handles new connections.
         /// </summary>
         /// <param name="ar">Async Result, the state contains this instance.</param>
-        private static void OnConnectCallback(IAsyncResult ar)
+        private static void OnTcpConnectCallback(IAsyncResult ar)
         {
             BaseServer server = (BaseServer)ar.AsyncState;
 
@@ -105,7 +106,7 @@ namespace Sustenet.Transport
                 TcpListener listener = server.tcpListener;
 
                 TcpClient client = listener.EndAcceptTcpClient(ar);
-                listener.BeginAcceptTcpClient(new AsyncCallback(OnConnectCallback), server);
+                listener.BeginAcceptTcpClient(new AsyncCallback(OnTcpConnectCallback), server);
 
                 ThreadManager.ExecuteOnMainThread(() =>
                 {

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -38,6 +38,7 @@ namespace Sustenet.Transport
         }
 
         private TcpListener tcpListener;
+        // UDP equivalent is in BaseClient.UdpHandler.socket
 
         public readonly ServerType serverType;
         public readonly string serverTypeName;

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -165,10 +165,19 @@ namespace Sustenet.Transport
 
                     clients[id].receivedData = new Packet();
 
-                    clients[id].onReceived.Run += (data) =>
+                    clients[id].onReceived.Run += (protocol, data) =>
                     {
                         // Convert the BaseClient to work for the server.
-                        clients[id].receivedData.Reset(HandleData(clients[id], data));
+                        switch(protocol)
+                        {
+                            case Protocols.TCP:
+                                clients[id].receivedData.Reset(HandleTcpData(clients[id], data));
+                                return;
+
+                            case Protocols.UDP:
+                                // Extra things to do goes here.
+                                return;
+                        }
                     };
                     // Clear the entry from the server.
                     clients[id].onDisconnected.Run += () => { ClearClient(id); };

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -377,7 +377,7 @@ namespace Sustenet.Transport
 
         public static void DebugServer(string serverTypeName, string msg)
         {
-            Console.WriteLine($"({serverTypeName}) {msg}");
+            Utilities.WriteLine($"({serverTypeName}) {msg}");
         }
     }
 }

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -242,7 +242,7 @@ namespace Sustenet.Transport
         #endregion
 
         #region Data Functions
-        private bool HandleData(BaseClient client, byte[] data)
+        private bool HandleTcpData(BaseClient client, byte[] data)
         {
             int packetLength = 0;
 
@@ -290,9 +290,24 @@ namespace Sustenet.Transport
             return false;
         }
 
+        private bool HandleUdpData(int clientId, Packet packet)
         {
-            Console.WriteLine($"({serverTypeName}) {msg}");
+
+            int packetLength = packet.ReadInt();
+            byte[] packetBytes = packet.ReadBytes(packetLength);
+
+            ThreadManager.ExecuteOnMainThread(() =>
+            {
+                using(Packet packet = new Packet(packetBytes))
+                {
+                    int packetId = packet.ReadInt();
+                    packetHandlers[packetId](clientId, packet);
+                }
+            });
+
+            return false;
         }
+        #endregion
 
         public static void DebugServer(string serverTypeName, string msg)
         {

--- a/src/Transport/BaseServer.cs
+++ b/src/Transport/BaseServer.cs
@@ -151,14 +151,14 @@ namespace Sustenet.Transport
                     }
 
                     // If this is a new client, set their endpoint and return.
-                    if(server.clients[clientId].udp.endPoint == null)
+                    if(server.clients[clientId].udp.endpoint == null)
                     {
-                        server.clients[clientId].udp.endPoint = endpoint;
+                        server.clients[clientId].udp.endpoint = endpoint;
                         return;
                     }
 
                     // Validate that the endpoints match to verify that the user is who they say they are.
-                    if(server.clients[clientId].udp.endPoint.ToString() == endpoint.ToString())
+                    if(server.clients[clientId].udp.endpoint.ToString() == endpoint.ToString())
                     {
                         server.clients[clientId].onReceived.RaiseEvent(Protocols.UDP, null);
                         server.HandleUdpData(server.clients[clientId].id, packet);

--- a/src/Transport/Messages/BaseClientHandlers/BaseClientCore.cs
+++ b/src/Transport/Messages/BaseClientHandlers/BaseClientCore.cs
@@ -32,9 +32,9 @@ namespace Sustenet.Transport.Messages.BaseClientHandlers
         /// <param name="packet">The packet to send.</param>
         internal static void SendTcpData(this BaseClient client, Packet packet)
         {
-            packet.WriteLength();
             try
             {
+                packet.WriteLength();
                 if(client.tcp.socket == null)
                 {
                     throw new Exception("TCPHandler socket is null.");

--- a/src/Transport/Messages/BaseClientHandlers/BaseClientCore.cs
+++ b/src/Transport/Messages/BaseClientHandlers/BaseClientCore.cs
@@ -47,5 +47,21 @@ namespace Sustenet.Transport.Messages.BaseClientHandlers
                 BaseClient.DebugClient(client.id, $"Error sending data via TCP to Client#{client.id}...: {e}");
             }
         }
+
+        internal static void SendUdpData(this BaseClient client, Packet packet)
+        {
+            try
+            {
+                packet.InsertInt(client.id);
+                if(BaseClient.UdpHandler.socket != null)
+                {
+                    BaseClient.UdpHandler.socket.BeginSend(packet.ToArray(), packet.Length(), null, null);
+                }
+            }
+            catch(Exception e)
+            {
+                BaseClient.DebugClient(client.id, $"Error sending data via UDP to Client #{client.id}...: {e}");
+            }
+        }
     }
 }

--- a/src/Transport/Messages/BaseClientHandlers/BaseClientCore.cs
+++ b/src/Transport/Messages/BaseClientHandlers/BaseClientCore.cs
@@ -33,15 +33,6 @@ namespace Sustenet.Transport.Messages.BaseClientHandlers
         internal static void SendTcpData(this BaseClient client, Packet packet)
         {
             packet.WriteLength();
-            client.SendData(packet);
-        }
-
-        /// <summary>
-        /// Sends a packet through the current stream.
-        /// </summary>
-        /// <param name="packet">The packet to be sent.</param>
-        internal static void SendData(this BaseClient client, Packet packet)
-        {
             try
             {
                 if(client.tcp.socket == null)

--- a/src/Transport/Messages/BaseClientHandlers/BaseClientCore.cs
+++ b/src/Transport/Messages/BaseClientHandlers/BaseClientCore.cs
@@ -52,6 +52,13 @@ namespace Sustenet.Transport.Messages.BaseClientHandlers
         {
             try
             {
+                if(client.id <= -1)
+                {
+                    BaseClient.DebugClient(client.id, "This client hasn't finished being setup by the server.");
+                    return;
+                }
+
+                packet.WriteLength();
                 packet.InsertInt(client.id);
                 if(BaseClient.UdpHandler.socket != null)
                 {

--- a/src/Transport/Messages/BaseClientHandlers/BaseClientReceive.cs
+++ b/src/Transport/Messages/BaseClientHandlers/BaseClientReceive.cs
@@ -18,7 +18,7 @@
 namespace Sustenet.Transport.Messages.BaseClientHandlers
 {
     /// <summary>
-    /// Messages that are sent from the Base Client.
+    /// Messages that are received by the Base Client.
     /// </summary>
-    static class BaseClientSend { }
+    static class BaseClientReceive { }
 }

--- a/src/Transport/Messages/BaseClientHandlers/BaseClientSend.cs
+++ b/src/Transport/Messages/BaseClientHandlers/BaseClientSend.cs
@@ -18,7 +18,7 @@
 namespace Sustenet.Transport.Messages.BaseClientHandlers
 {
     /// <summary>
-    /// Messages that are received by the Base Client.
+    /// Messages that are sent from the Base Client.
     /// </summary>
-    static class BaseClientReceive { }
+    static class BaseClientSend { }
 }

--- a/src/Transport/Messages/BaseServerHandlers/BaseServerCore.cs
+++ b/src/Transport/Messages/BaseServerHandlers/BaseServerCore.cs
@@ -33,8 +33,7 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
         /// <param name="packet">The packet to send.</param>
         internal static void SendTcpData(this BaseServer server, int toClient, Packet packet)
         {
-            packet.WriteLength();
-            server.clients[toClient].SendData(packet);
+            server.clients[toClient].SendTcpData(packet);
         }
 
         /// <summary>
@@ -44,10 +43,9 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
         /// <param name="packet">The packet to send.</param>
         internal static void SendTcpDataToAll(this BaseServer server, Packet packet)
         {
-            packet.WriteLength();
             foreach(BaseClient client in server.clients.Values)
             {
-                client.SendData(packet);
+                client.SendTcpData(packet);
             }
         }
 
@@ -59,12 +57,11 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
         /// <param name="packet">The packet to send.</param>
         internal static void SendTcpDataToAll(this BaseServer server, int exceptClient, Packet packet)
         {
-            packet.WriteLength();
             foreach(BaseClient client in server.clients.Values)
             {
                 if(client.id != exceptClient)
                 {
-                    client.SendData(packet);
+                    client.SendTcpData(packet);
                 }
             }
         }

--- a/src/Transport/Messages/BaseServerHandlers/BaseServerCore.cs
+++ b/src/Transport/Messages/BaseServerHandlers/BaseServerCore.cs
@@ -17,6 +17,7 @@
 
 namespace Sustenet.Transport.Messages.BaseServerHandlers
 {
+    using System;
     using Network;
     using BaseClientHandlers;
 
@@ -26,18 +27,48 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
     static class BaseServerCore
     {
         /// <summary>
-        /// Send data to a single client.
+        /// Send TCP data to a single client.
         /// </summary>
         /// <param name="server">The server to send from.</param>
         /// <param name="toClient">The client to send data to.</param>
         /// <param name="packet">The packet to send.</param>
         internal static void SendTcpData(this BaseServer server, int toClient, Packet packet)
         {
-            server.clients[toClient].SendTcpData(packet);
+            try
+            {
+                server.clients[toClient].SendTcpData(packet);
+            }
+            catch(Exception e)
+            {
+                BaseClient.DebugClient(toClient, $"Error sending data via TCP from Client #{toClient}...: {e}");
+            }
         }
 
         /// <summary>
-        /// Send data to all clients.
+        /// Send UDP data to a single client.
+        /// </summary>
+        /// <param name="server">The server to send from.</param>
+        /// <param name="toClient">The client to send data to.</param>
+        /// <param name="packet">The packet to send.</param>
+        internal static void SendUdpData(this BaseServer server, int toClient, Packet packet)
+        {
+            try
+            {
+                BaseClient client = server.clients[toClient];
+
+                if(client.udp.endPoint != null)
+                {
+                    BaseClient.UdpHandler.socket.BeginSend(packet.ToArray(), packet.Length(), client.udp.endPoint, null, null);
+                }
+            }
+            catch(Exception e)
+            {
+                BaseClient.DebugClient(toClient, $"Error sending data via UDP from Client #{toClient}...: {e}");
+            }
+        }
+
+        /// <summary>
+        /// Send TCP data to all clients.
         /// </summary>
         /// <param name="server">The server to send from.</param>
         /// <param name="packet">The packet to send.</param>
@@ -50,7 +81,20 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
         }
 
         /// <summary>
-        /// Send data to all clients except one.
+        /// Send UDP data to all clients.
+        /// </summary>
+        /// <param name="server">The server to send from.</param>
+        /// <param name="packet">The packet to send.</param>
+        internal static void SendUdpDataToAll(this BaseServer server, Packet packet)
+        {
+            foreach(BaseClient client in server.clients.Values)
+            {
+                client.SendTcpData(packet);
+            }
+        }
+
+        /// <summary>
+        /// Send TCP data to all clients except one.
         /// </summary>
         /// <param name="server">The server to send from.</param>
         /// <param name="exceptClient">The client to exclude from the mass send.</param>
@@ -61,7 +105,24 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
             {
                 if(client.id != exceptClient)
                 {
-                    client.SendTcpData(packet);
+                    client.SendUdpData(packet);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Send UDP data to all clients except one.
+        /// </summary>
+        /// <param name="server">The server to send from.</param>
+        /// <param name="exceptClient">The client to exclude from the mass send.</param>
+        /// <param name="packet">The packet to send.</param>
+        internal static void SendUdpDataToAll(this BaseServer server, int exceptClient, Packet packet)
+        {
+            foreach(BaseClient client in server.clients.Values)
+            {
+                if(client.id != exceptClient)
+                {
+                    client.SendUdpData(packet);
                 }
             }
         }

--- a/src/Transport/Messages/BaseServerHandlers/BaseServerCore.cs
+++ b/src/Transport/Messages/BaseServerHandlers/BaseServerCore.cs
@@ -54,6 +54,7 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
         {
             try
             {
+                packet.WriteLength();
                 BaseClient client = server.clients[toClient];
 
                 if(client.udp.endpoint != null)

--- a/src/Transport/Messages/BaseServerHandlers/BaseServerCore.cs
+++ b/src/Transport/Messages/BaseServerHandlers/BaseServerCore.cs
@@ -56,9 +56,9 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
             {
                 BaseClient client = server.clients[toClient];
 
-                if(client.udp.endPoint != null)
+                if(client.udp.endpoint != null)
                 {
-                    BaseClient.UdpHandler.socket.BeginSend(packet.ToArray(), packet.Length(), client.udp.endPoint, null, null);
+                    BaseClient.UdpHandler.socket.BeginSend(packet.ToArray(), packet.Length(), client.udp.endpoint, null, null);
                 }
             }
             catch(Exception e)

--- a/src/Transport/Messages/BaseServerHandlers/BaseServerSend.cs
+++ b/src/Transport/Messages/BaseServerHandlers/BaseServerSend.cs
@@ -39,5 +39,20 @@ namespace Sustenet.Transport.Messages.BaseServerHandlers
                 server.SendTcpData(toClient, packet);
             }
         }
+
+        #region Initialization Section
+        /// <summary>
+        /// Tells a client that a UDP connnection is ready.
+        /// </summary>
+        /// <param name="server">The server to run this on.</param>
+        /// <param name="toClient">The client to notify that the connection is ready.</param>
+        internal static void UdpReady(this BaseServer server, int toClient)
+        {
+            using(Packet packet = new Packet((int)ServerPackets.udpReady))
+            {
+                server.SendUdpData(toClient, packet);
+            }
+        }
+        #endregion
     }
 }

--- a/src/Transport/Messages/ClientHandlers/ClientReceive.cs
+++ b/src/Transport/Messages/ClientHandlers/ClientReceive.cs
@@ -55,5 +55,18 @@ namespace Sustenet.Transport.Messages.ClientHandlers
 
             BaseClient.DebugClient(client.id, $"Welcome, {username}!");
         }
+
+        /// <summary>
+        /// Updates the client's position. Some prediction should be included to smooth things out.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="packet"></param>
+        internal static void UpdatePosition(this Client client, Packet packet)
+        {
+            float xPos = packet.ReadFloat();
+            float yPos = packet.ReadFloat();
+            float zPos = packet.ReadFloat();
+            BaseClient.DebugClient(client.id, $"Moved to ({xPos}, {yPos}, {zPos})");
+        }
     }
 }

--- a/src/Transport/Messages/ClientHandlers/ClientReceive.cs
+++ b/src/Transport/Messages/ClientHandlers/ClientReceive.cs
@@ -37,6 +37,7 @@ namespace Sustenet.Transport.Messages.ClientHandlers
             BaseClient.DebugClient(client.id, $"(Server Message) {msg}");
         }
 
+        #region Initialization Section
         /// <summary>
         /// Initializes the client's ID and username.
         /// If the client is a Cluster, the username is the key.
@@ -54,8 +55,23 @@ namespace Sustenet.Transport.Messages.ClientHandlers
             client.id = id;
 
             BaseClient.DebugClient(client.id, $"Welcome, {username}!");
+
+            client.StartUdp();
         }
 
+        /// <summary>
+        /// This is received when the server has successfully setup the udp connection.
+        /// </summary>
+        /// <param name="client">The client whose ID and username should be changed.</param>
+        /// <param name="packet">The packet containing the new client ID.</param>
+        internal static void UdpConnected(this Client client, Packet packet)
+        {
+            BaseClient.DebugClient(client.id, $"A UDP has been successfully made.");
+            client.onInitialized.RaiseEvent();
+        }
+        #endregion
+
+        #region Movement Section
         /// <summary>
         /// Updates the client's position. Some prediction should be included to smooth things out.
         /// </summary>
@@ -68,5 +84,6 @@ namespace Sustenet.Transport.Messages.ClientHandlers
             float zPos = packet.ReadFloat();
             BaseClient.DebugClient(client.id, $"Moved to ({xPos}, {yPos}, {zPos})");
         }
+        #endregion
     }
 }

--- a/src/Transport/Messages/ClientHandlers/ClientSend.cs
+++ b/src/Transport/Messages/ClientHandlers/ClientSend.cs
@@ -51,6 +51,19 @@ namespace Sustenet.Transport.Messages.ClientHandlers
                 BaseClient.DebugClient(client.id, "Cannot login unless connected to a Master Server.");
             }
         }
+
+        /// <summary>
+        /// Sends a packet with only the client ID to start a UDP connection.
+        /// </summary>
+        /// <param name="client">The client requesting for a UDP connection.</param>
+        internal static void StartUdp(this Client client)
+        {
+            // Tell the server to create an endpoint with this client
+            using(Packet packet = new Packet((int)ClientPackets.startUdp))
+            {
+                client.SendUdpData(packet);
+            }
+        }
         #endregion
 
         #region Movement Section

--- a/src/Transport/Messages/ClientHandlers/ClientSend.cs
+++ b/src/Transport/Messages/ClientHandlers/ClientSend.cs
@@ -20,12 +20,15 @@ namespace Sustenet.Transport.Messages.ClientHandlers
     using Network;
     using Clients;
     using BaseClientHandlers;
+    using Utils;
+    using System;
 
     /// <summary>
     /// TODO: Documentation
     /// </summary>
     static class ClientSend
     {
+        #region Initialization Section
         /// <summary>
         /// Sends a request to the server to login.
         /// TODO: Authentication and persistent sessions.
@@ -48,5 +51,39 @@ namespace Sustenet.Transport.Messages.ClientHandlers
                 BaseClient.DebugClient(client.id, "Cannot login unless connected to a Master Server.");
             }
         }
+        #endregion
+
+        #region Movement Section
+        /// <summary>
+        /// Moves the client in the desired direction.
+        /// </summary>
+        /// <param name="client">The client to move.</param>
+        /// <param name="velocity">How fast they should move (validated by the server).</param>
+        internal static void MoveTo(this Client client, float[] velocity)
+        {
+            if(velocity == null || velocity.Length < 3)
+            {
+                BaseClient.DebugClient(client.id, "The velocity is either null or does not have an x, y, z.");
+                return;
+            }
+
+            // PENDING UPDATE: Change to ConnectionType.ClusterServer once the ClusterServer is actually being used.
+            if(client.activeConnection == Client.ConnectionType.MasterServer)
+            {
+                using(Packet packet = new Packet((int)ClientPackets.moveTo))
+                {
+                    packet.Write(velocity[0]);
+                    packet.Write(velocity[1]);
+                    packet.Write(velocity[2]);
+
+                    client.SendUdpData(packet);
+                }
+            }
+            else
+            {
+                BaseClient.DebugClient(client.id, "Can't move until connected to a Cluster Server.");
+            }
+        }
+        #endregion
     }
 }

--- a/src/Transport/Messages/MasterHandlers/MasterReceive.cs
+++ b/src/Transport/Messages/MasterHandlers/MasterReceive.cs
@@ -42,7 +42,7 @@ namespace Sustenet.Transport.Messages.MasterHandlers
                 server.Message(fromClient, "Please enter a username longer than 2 characters. Disconnecting.");
                 server.DisconnectClient(fromClient);
 
-                MasterServer.DebugServer(server.serverType, $"Disconnecting Client#{fromClient} for having the username '{username}' which is too short.");
+                MasterServer.DebugServer(server.serverTypeName, $"Disconnecting Client#{fromClient} for having the username '{username}' which is too short.");
 
                 return;
             }
@@ -84,7 +84,7 @@ namespace Sustenet.Transport.Messages.MasterHandlers
                 server.Message(fromClient, "Incorrect passphrase. Disconnecting.");
                 server.DisconnectClient(fromClient);
 
-                MasterServer.DebugServer(server.serverType, $"Disconnecting Client#{fromClient} for answering their passphrase incorrectly.");
+                MasterServer.DebugServer(server.serverTypeName, $"Disconnecting Client#{fromClient} for answering their passphrase incorrectly.");
 
                 return;
             }

--- a/src/Transport/Messages/MasterHandlers/MasterReceive.cs
+++ b/src/Transport/Messages/MasterHandlers/MasterReceive.cs
@@ -116,7 +116,7 @@ namespace Sustenet.Transport.Messages.MasterHandlers
 
             // TODO: Update server-side velocity, send new position back and sync on the client-side.
 
-            server.UpdatePosition(fromClient, new float[] { 1.0005f, 2.512f, 3.245f });
+            server.SendUpdatedPosition(fromClient, new float[] { 1.0005f, 2.512f, 3.245f });
         }
         #endregion
     }

--- a/src/Transport/Messages/MasterHandlers/MasterReceive.cs
+++ b/src/Transport/Messages/MasterHandlers/MasterReceive.cs
@@ -20,12 +20,14 @@ namespace Sustenet.Transport.Messages.MasterHandlers
     using Master;
     using Network;
     using BaseServerHandlers;
+    using Utils.Mathematics;
 
     /// <summary>
     /// Handles data the master server may receive.
     /// </summary>
     static class MasterReceive
     {
+        #region Initialization Section
         /// <summary>
         /// Gives the client an ID and checks if the current username belongs to them.
         /// </summary>
@@ -89,5 +91,33 @@ namespace Sustenet.Transport.Messages.MasterHandlers
                 return;
             }
         }
+        #endregion
+
+        #region Movement Section
+        /// <summary>
+        /// Verifies that a player has a legal velocity.
+        /// </summary>
+        /// <param name="server">The Cluster Server to run this on.</param>
+        /// <param name="fromClient">The client sending this packet.</param>
+        /// <param name="packet">The packet containing the 3 float positions.</param>
+        internal static void ValidateMoveTo(this MasterServer server, int fromClient, Packet packet)
+        {
+            float xPos = packet.ReadFloat();
+            float yPos = packet.ReadFloat();
+            float zPos = packet.ReadFloat();
+
+            // Validations
+            if(!xPos.InRange(-5, 5) || !yPos.InRange(-5, 5) || !zPos.InRange(-5, 5))
+            {
+                return;
+            }
+
+            // TODO: PSEUDO => if zPos != 0 && !grounded, cancel the operation.
+
+            // TODO: Update server-side velocity, send new position back and sync on the client-side.
+
+            server.UpdatePosition(fromClient, new float[] { 1.0005f, 2.512f, 3.245f });
+        }
+        #endregion
     }
 }

--- a/src/Transport/Messages/MasterHandlers/MasterSend.cs
+++ b/src/Transport/Messages/MasterHandlers/MasterSend.cs
@@ -70,7 +70,7 @@ namespace Sustenet.Transport.Messages.MasterHandlers
         /// <param name="username">The client's username.</param>
         internal static void InitializeLogin(this MasterServer server, int toClient, string username)
         {
-            MasterServer.DebugServer(server.serverType, $"Setting Client#{toClient}'s username to {username}.");
+            MasterServer.DebugServer(server.serverTypeName, $"Setting Client#{toClient}'s username to {username}.");
 
             /**
              * TODO:

--- a/src/Transport/Messages/MasterHandlers/MasterSend.cs
+++ b/src/Transport/Messages/MasterHandlers/MasterSend.cs
@@ -30,40 +30,6 @@ namespace Sustenet.Transport.Messages.MasterHandlers
     {
         #region Initialization Section
         /// <summary>
-        /// Generates a 128-156 character passphrase, encrypts it using an RSA key,
-        /// stores the passphrase in the potential Cluster Client's name, and then
-        /// sends it to the potential Cluster Client.
-        /// </summary>
-        /// <param name="server">The server to run this on.</param>
-        /// <param name="toClient">The client to send the passphrase to.</param>
-        /// <param name="keyName">The name of the key to use.</param>
-        internal static void Passphrase(this MasterServer server, int toClient, string keyName)
-        {
-            // If the key doesn't exists...
-            if(!RSAManager.KeyExists(keyName))
-            {
-                // ...do absolutely nothing. Just stay silent
-                return;
-            }
-
-            // ...otherwise, serve a passphrase.
-
-            string passphrase = PassphraseGenerator.GeneratePassphrase();
-            AESManager.EncryptedData data = AESManager.Encrypt(keyName, passphrase);
-
-            server.clients[toClient].name = passphrase; // Set the client name to the passphrase to store it.
-
-            using(Packet packet = new Packet((int)ServerPackets.passphrase))
-            {
-                packet.Write(keyName);
-                packet.Write(Convert.ToBase64String(data.cypher));
-                packet.Write(Convert.ToBase64String(data.iv));
-
-                server.SendTcpData(toClient, packet);
-            }
-        }
-
-        /// <summary>
         /// Sends a Client their validated login information.
         /// </summary>
         /// <param name="server">The Master Server to run this on.</param>
@@ -101,6 +67,40 @@ namespace Sustenet.Transport.Messages.MasterHandlers
             using(Packet packet = new Packet((int)ServerPackets.initializeCluster))
             {
                 packet.Write(clusterName);
+
+                server.SendTcpData(toClient, packet);
+            }
+        }
+
+        /// <summary>
+        /// Generates a 128-156 character passphrase, encrypts it using an RSA key,
+        /// stores the passphrase in the potential Cluster Client's name, and then
+        /// sends it to the potential Cluster Client.
+        /// </summary>
+        /// <param name="server">The server to run this on.</param>
+        /// <param name="toClient">The client to send the passphrase to.</param>
+        /// <param name="keyName">The name of the key to use.</param>
+        internal static void Passphrase(this MasterServer server, int toClient, string keyName)
+        {
+            // If the key doesn't exists...
+            if(!RSAManager.KeyExists(keyName))
+            {
+                // ...do absolutely nothing. Just stay silent
+                return;
+            }
+
+            // ...otherwise, serve a passphrase.
+
+            string passphrase = PassphraseGenerator.GeneratePassphrase();
+            AESManager.EncryptedData data = AESManager.Encrypt(keyName, passphrase);
+
+            server.clients[toClient].name = passphrase; // Set the client name to the passphrase to store it.
+
+            using(Packet packet = new Packet((int)ServerPackets.passphrase))
+            {
+                packet.Write(keyName);
+                packet.Write(Convert.ToBase64String(data.cypher));
+                packet.Write(Convert.ToBase64String(data.iv));
 
                 server.SendTcpData(toClient, packet);
             }

--- a/src/Transport/Messages/MasterHandlers/MasterSend.cs
+++ b/src/Transport/Messages/MasterHandlers/MasterSend.cs
@@ -28,6 +28,7 @@ namespace Sustenet.Transport.Messages.MasterHandlers
     /// </summary>
     static class MasterSend
     {
+        #region Initialization Section
         /// <summary>
         /// Generates a 128-156 character passphrase, encrypts it using an RSA key,
         /// stores the passphrase in the potential Cluster Client's name, and then
@@ -104,5 +105,26 @@ namespace Sustenet.Transport.Messages.MasterHandlers
                 server.SendTcpData(toClient, packet);
             }
         }
+        #endregion
+
+        #region Movement Section
+        internal static void UpdatePosition(this MasterServer server, int toClient, float[] newPos)
+        {
+            if(newPos == null || newPos.Length < 3)
+            {
+                MasterServer.DebugServer(server.serverTypeName, "The new position is either null or doesn't have an x, y, and z.");
+                return;
+            }
+
+            using(Packet packet = new Packet((int)ServerPackets.updatePosition))
+            {
+                packet.Write(newPos[0]);
+                packet.Write(newPos[1]);
+                packet.Write(newPos[2]);
+
+                server.SendUdpData(toClient, packet);
+            }
+        }
+        #endregion
     }
 }

--- a/src/Transport/Messages/MasterHandlers/MasterSend.cs
+++ b/src/Transport/Messages/MasterHandlers/MasterSend.cs
@@ -108,7 +108,7 @@ namespace Sustenet.Transport.Messages.MasterHandlers
         #endregion
 
         #region Movement Section
-        internal static void UpdatePosition(this MasterServer server, int toClient, float[] newPos)
+        internal static void SendUpdatedPosition(this MasterServer server, int toClient, float[] newPos)
         {
             if(newPos == null || newPos.Length < 3)
             {

--- a/src/Transport/Protocols.cs
+++ b/src/Transport/Protocols.cs
@@ -1,0 +1,25 @@
+﻿/**
+ * Copyright (C) 2020 Quaint Studios, Kristopher Ali (Makosai) <kristopher.ali.dev@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Sustenet.Transport
+{
+    public enum Protocols
+    {
+        TCP,
+        UDP
+    }
+}

--- a/src/Utils/Constants.cs
+++ b/src/Utils/Constants.cs
@@ -1,12 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿/**
+ * Copyright (C) 2020 Quaint Studios, Kristopher Ali (Makosai) <kristopher.ali.dev@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 namespace Sustenet.Utils
 {
     class Constants
     {
-        public const bool DEBUGGING = false;
+        public const bool DEBUGGING = true;
 
         /// <summary>
         /// How many ticks are in a second.

--- a/src/Utils/UMath.cs
+++ b/src/Utils/UMath.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Sustenet.Utils.Mathematics
+{
+    /// <summary>
+    /// The Math Utility class.
+    /// </summary>
+    public static class UMath
+    {
+        #region InRange
+        // TODO: Expand on this, adding more overloads and types.
+
+        /// <summary>
+        /// Determines if a number is in range of min and max (inclusive).
+        /// </summary>
+        public static bool InRange(this int num, int min, int max)
+        {
+            return num >= min && num <= max;
+        }
+
+        /// <summary>
+        /// Determines if a number is in range of min and max (inclusive).
+        /// </summary>
+        public static bool InRange(this float num, float min, float max)
+        {
+            return num >= min && num <= max;
+        }
+        #endregion
+    }
+}

--- a/src/Utils/UMath.cs
+++ b/src/Utils/UMath.cs
@@ -1,6 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿/**
+ * Copyright (C) 2020 Quaint Studios, Kristopher Ali (Makosai) <kristopher.ali.dev@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 namespace Sustenet.Utils.Mathematics
 {

--- a/src/Utils/Utilities.cs
+++ b/src/Utils/Utilities.cs
@@ -1,6 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿/**
+ * Copyright (C) 2020 Quaint Studios, Kristopher Ali (Makosai) <kristopher.ali.dev@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
 using System.Text.RegularExpressions;
 
 namespace Sustenet.Utils

--- a/src/World/ClusterServer.cs
+++ b/src/World/ClusterServer.cs
@@ -32,7 +32,7 @@ namespace Sustenet.World
         /// Creates a Cluster Server that creates Fragment Servers to be used.
         /// TODO: Will currently only create a single server for itself.
         /// </summary>
-        public ClusterServer(int _maxConnections = 0, ushort _port = 6257) : base(_maxConnections, _port)
+        public ClusterServer(int _maxConnections = 0, ushort _port = 6257) : base(ServerType.ClusterServer, _maxConnections, _port)
         {
             Start(ServerType.ClusterServer);
 


### PR DESCRIPTION
**Fixed**
- `Packet` constructor not initializing variables properly in all constructors.

**Added**
- `Protocols` enums for TCP and UDP.
- Methods for sending and receiving via UDP.
- Utility namespace, class, and methods for mathematics.
- `Login()` to the command-line client.

**Removed**
- `lock` from `stream`.
  - _"Since the stream can be null sometimes, `lock` was removed. Instead, null should be sufficient enough."_
- `socket` and `endpoint` disposal for `UdpHandler`.

**Updated**
- The SustenetClient solution included files.
  - _"The new structure for the message handlers has been replaced with the old structure in the client solution."_
- `Stream/Socket.Dispose()` to only call `Socket.Close()` instead.
  - _"`Socket.Close()` will handle disposing both the socket and stream. So just calling `Close()` on the socket will handle everything. This also solves an issue with `Dispose()` in .NET 4.5 since it's not an exposed method."_
- Client `AsyncCallback` states.
  - _"The client's callback methods now have the client passed through them as a state."_
- Command-line client default count from 5000 to 1.
- `BaseServer` constructor to initialize the `serverType` and `serverTypeName`.
- `DebugServer()` to use `serverTypeName` and `Utilities.WriteLine()`.
- `SendData()` to `SendTcpData()` by merging their functionality.
  - _"This was done because all `SendData()` did was write the packet length."_
- `UdpClient socket` to static so only one exists.
- Event handlers to use the new TCP & UDP structure.